### PR TITLE
add CLI command registration for legionio lex exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-03-31
+
+### Added
+- CLI command registration: `legionio lex exec github auth status|login` and `legionio lex exec github app setup|complete_setup`
+- `CLI::AuthRunner` and `CLI::AppRunner` wrapper classes for `lex exec` dispatch
+- Self-registering CLI manifest at `~/.legionio/cache/cli/lex-github.json` (written on first require)
+- Require redirect `lib/lex/github.rb` for `lex exec` compatibility
+
 ## [0.3.1] - 2026-03-30
 
 ### Changed

--- a/lib/legion/extensions/github.rb
+++ b/lib/legion/extensions/github.rb
@@ -37,11 +37,48 @@ require 'legion/extensions/github/runners/releases'
 require 'legion/extensions/github/runners/deployments'
 require 'legion/extensions/github/runners/repository_webhooks'
 require 'legion/extensions/github/client'
+require 'legion/extensions/github/cli/runner'
 
 module Legion
   module Extensions
     module Github
       extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core, false
+
+      CLI_COMMANDS = {
+        'auth' => {
+          class_name: 'Legion::Extensions::Github::CLI::AuthRunner',
+          methods:    {
+            'login'  => { desc: 'Authenticate with GitHub via OAuth browser flow', args: '' },
+            'status' => { desc: 'Show current GitHub authentication status', args: '' }
+          }
+        },
+        'app'  => {
+          class_name: 'Legion::Extensions::Github::CLI::AppRunner',
+          methods:    {
+            'setup'          => { desc: 'Create a new GitHub App via manifest flow', args: '' },
+            'complete_setup' => { desc: 'Complete GitHub App setup with authorization code', args: '' }
+          }
+        }
+      }.freeze
+
+      begin
+        manifest_dir = ::File.expand_path('~/.legionio/cache/cli')
+        manifest_path = ::File.join(manifest_dir, 'lex-github.json')
+        unless ::File.exist?(manifest_path) && ::File.read(manifest_path).include?(VERSION)
+          require 'fileutils'
+          ::FileUtils.mkdir_p(manifest_dir)
+          serialized = CLI_COMMANDS.transform_values do |cmd|
+            { 'class'   => cmd[:class_name],
+              'methods' => cmd[:methods].transform_values { |m| { 'desc' => m[:desc], 'args' => m[:args] } } }
+          end
+          ::File.write(manifest_path, ::JSON.pretty_generate(
+                                        'gem' => 'lex-github', 'version' => VERSION,
+                                        'alias' => 'github', 'commands' => serialized
+                                      ))
+        end
+      rescue StandardError => e
+        warn "[lex-github] CLI manifest write skipped: #{e.message}" if ENV['LEGION_DEBUG']
+      end
     end
   end
 end

--- a/lib/legion/extensions/github/cli/runner.rb
+++ b/lib/legion/extensions/github/cli/runner.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'legion/extensions/github/cli/auth'
+require 'legion/extensions/github/cli/app'
+require 'legion/extensions/github/app/runners/credential_store'
+
+module Legion
+  module Extensions
+    module Github
+      module CLI
+        class AuthRunner
+          include Legion::Logging::Helper if defined?(Legion::Logging::Helper)
+          include Github::CLI::Auth
+          include Github::App::Runners::CredentialStore
+
+          def credential_fingerprint(auth_type:, identifier:)
+            "#{auth_type}:#{identifier}"
+          end
+
+          def vault_get(path)
+            return nil unless defined?(Legion::Crypt)
+
+            ::Legion::Crypt.get(path)
+          rescue StandardError => e
+            log.warn("[lex-github] vault_get failed: #{e.message}")
+            nil
+          end
+
+          def cache_connected?
+            defined?(Legion::Cache) && ::Legion::Cache.connected?
+          rescue StandardError => e
+            log.debug("[lex-github] cache_connected? check failed: #{e.message}")
+            false
+          end
+
+          def local_cache_connected?
+            defined?(Legion::Cache::Local) && ::Legion::Cache::Local.connected?
+          rescue StandardError => e
+            log.debug("[lex-github] local_cache_connected? check failed: #{e.message}")
+            false
+          end
+
+          def cache_get(key)
+            ::Legion::Cache.get(key)
+          rescue StandardError => e
+            log.debug("[lex-github] cache_get failed: #{e.message}")
+            nil
+          end
+
+          def local_cache_get(key)
+            ::Legion::Cache::Local.get(key)
+          rescue StandardError => e
+            log.debug("[lex-github] local_cache_get failed: #{e.message}")
+            nil
+          end
+
+          def cache_set(key, value, ttl: 300)
+            ::Legion::Cache.set(key, value, ttl)
+          rescue StandardError => e
+            log.debug("[lex-github] cache_set failed: #{e.message}")
+            nil
+          end
+
+          def local_cache_set(key, value, ttl: 300)
+            ::Legion::Cache::Local.set(key, value, ttl)
+          rescue StandardError => e
+            log.debug("[lex-github] local_cache_set failed: #{e.message}")
+            nil
+          end
+        end
+
+        class AppRunner
+          include Legion::Logging::Helper if defined?(Legion::Logging::Helper)
+          include Github::CLI::App
+          include Github::App::Runners::CredentialStore
+
+          def credential_fingerprint(auth_type:, identifier:)
+            "#{auth_type}:#{identifier}"
+          end
+
+          def vault_get(path)
+            return nil unless defined?(Legion::Crypt)
+
+            ::Legion::Crypt.get(path)
+          rescue StandardError => e
+            log.warn("[lex-github] vault_get failed: #{e.message}")
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/github/version.rb
+++ b/lib/legion/extensions/github/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Github
-      VERSION = '0.3.1'
+      VERSION = '0.3.2'
     end
   end
 end

--- a/lib/lex/github.rb
+++ b/lib/lex/github.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Redirect for `require 'lex/github'` (used by `legionio lex exec`)
+require 'legion/extensions/github'


### PR DESCRIPTION
## Summary
- Add `CLI::AuthRunner` and `CLI::AppRunner` wrapper classes enabling `legionio lex exec github auth status|login` and `legionio lex exec github app setup|complete_setup`
- Self-registering CLI manifest written to `~/.legionio/cache/cli/lex-github.json` on first require (no LegionIO dependency needed)
- Require redirect at `lib/lex/github.rb` for `lex exec` require-path compatibility

## Test plan
- [x] 234 specs passing, 0 failures
- [x] 94.5% line coverage
- [x] rubocop clean (0 offenses)
- [x] Manifest write verified locally